### PR TITLE
upgrading scala to 2.13.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 
     <groupId>com.ubirch.util</groupId>
     <artifactId>ubirch-oidc-utils_${scala.major.version}</artifactId>
-    <version>0.8.16-SNAPSHOT</version>
+    <version>0.8.16</version>
     <packaging>jar</packaging>
 
     <licenses>
@@ -77,12 +77,12 @@
         <scalatest.version>3.2.10</scalatest.version>
         <scalatest-embedded-redis.version>0.4.0</scalatest-embedded-redis.version>
 
-        <ubirch-crypto.version>0.5.4-SNAPSHOT</ubirch-crypto.version>
-        <ubirch-json.version>0.5.3-SNAPSHOT</ubirch-json.version>
-        <ubirch-redis.version>0.6.2-SNAPSHOT</ubirch-redis.version>
-        <ubirch-response.version>0.5.2-SNAPSHOT</ubirch-response.version>
-        <ubirch-id-service-client.version>0.6.6-SNAPSHOT</ubirch-id-service-client.version>
-        <ubirch-user-service-client.version>1.0.6-SNAPSHOT</ubirch-user-service-client.version>
+        <ubirch-crypto.version>0.5.4</ubirch-crypto.version>
+        <ubirch-json.version>0.5.3</ubirch-json.version>
+        <ubirch-redis.version>0.6.2</ubirch-redis.version>
+        <ubirch-response.version>0.5.2</ubirch-response.version>
+        <ubirch-id-service-client.version>0.6.6</ubirch-id-service-client.version>
+        <ubirch-user-service-client.version>1.0.6</ubirch-user-service-client.version>
 
         <akka-http.version>10.2.7</akka-http.version>
 
@@ -354,6 +354,19 @@
                 <configuration>
                     <skip>false</skip>
                 </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -71,10 +71,11 @@
         <timestamp>${maven.build.timestamp}</timestamp>
         <maven.build.timestamp.format>yyyyMMddHHmm</maven.build.timestamp.format>
 
-        <scala.major.version>2.11</scala.major.version>
-        <scala.version>2.11.12</scala.version>
-        <scala.compat.version>2.11</scala.compat.version>
-        <scalatest.version>3.0.5</scalatest.version>
+        <scala.major.version>2.13</scala.major.version>
+        <scala.version>2.13.6</scala.version>
+        <scala.compat.version>2.13</scala.compat.version>
+        <scalatest.version>3.2.10</scalatest.version>
+        <scalatest-embedded-redis.version>0.4.0</scalatest-embedded-redis.version>
 
         <ubirch-crypto.version>0.5.4-SNAPSHOT</ubirch-crypto.version>
         <ubirch-json.version>0.5.3-SNAPSHOT</ubirch-json.version>
@@ -83,14 +84,14 @@
         <ubirch-id-service-client.version>0.6.6-SNAPSHOT</ubirch-id-service-client.version>
         <ubirch-user-service-client.version>1.0.6-SNAPSHOT</ubirch-user-service-client.version>
 
-        <akka-http.version>10.1.3</akka-http.version>
+        <akka-http.version>10.2.7</akka-http.version>
 
-        <akka-stream.version>2.5.11</akka-stream.version>
-        <joda-time.version>2.10</joda-time.version>
-        <json4s.version>3.6.0</json4s.version>
-        <scala-logging.version>3.7.2</scala-logging.version>
-        <slf4j.version>1.7.21</slf4j.version>
-        <logback.version>1.1.7</logback.version>
+        <akka-stream.version>2.6.18</akka-stream.version>
+        <joda-time.version>2.10.13</joda-time.version>
+        <json4s.version>4.0.3</json4s.version>
+        <scala-logging.version>3.9.4</scala-logging.version>
+        <slf4j.version>1.7.32</slf4j.version>
+        <logback.version>1.2.10</logback.version>
 
         <!-- plugins -->
         <maven-deploy-plugin.version>2.8.2</maven-deploy-plugin.version>
@@ -169,6 +170,14 @@
             <version>${akka-http.version}</version>
         </dependency>
 
+        <!-- https://mvnrepository.com/artifact/com.typesafe.akka/akka-stream-testkit -->
+        <dependency>
+            <groupId>com.typesafe.akka</groupId>
+            <artifactId>akka-stream-testkit_${scala.compat.version}</artifactId>
+            <version>${akka-stream.version}</version>
+            <scope>test</scope>
+        </dependency>
+
         <dependency>
             <groupId>org.scalatest</groupId>
             <artifactId>scalatest_${scala.compat.version}</artifactId>
@@ -178,7 +187,7 @@
         <dependency>
             <groupId>com.github.sebruck</groupId>
             <artifactId>scalatest-embedded-redis_${scala.major.version}</artifactId>
-            <version>0.2.0</version>
+            <version>${scalatest-embedded-redis.version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/src/main/scala/com.ubirch.util.oidc/directive/OidcDirective.scala
+++ b/src/main/scala/com.ubirch.util.oidc/directive/OidcDirective.scala
@@ -42,7 +42,7 @@ class OidcDirective()(implicit system: ActorSystem, httpClient: HttpExt, materia
   implicit private val formatter: Formats = JsonFormats.default
 
   private val envid = config.getString("ubirch.envid").toLowerCase
-  private val redis = RedisClientUtil.getRedisClient
+  private val redis = RedisClientUtil.getRedisClient()
   private val refreshIntervalSeconds = OidcUtilsConfig.redisUpdateExpirySeconds()
   private val skipEnvChecking = OidcUtilsConfig.skipEnvChecking()
   private val allowInvalidSignature = OidcUtilsConfig.allowInvalidSignature()

--- a/src/test/scala/com/ubirch/util/oidc/directive/OidcDirectiveSpec.scala
+++ b/src/test/scala/com/ubirch/util/oidc/directive/OidcDirectiveSpec.scala
@@ -1,7 +1,5 @@
 package com.ubirch.util.oidc.directive
 
-import java.util.UUID
-
 import akka.http.scaladsl.model.headers.{Authorization, OAuth2BearerToken}
 import akka.http.scaladsl.model.{HttpHeader, StatusCodes}
 import akka.http.scaladsl.server.Directives.{complete, pathSingleSlash}
@@ -15,9 +13,12 @@ import com.ubirch.util.oidc.util.OidcUtil
 import com.ubirch.util.redis.RedisClientUtil
 import com.ubirch.util.redis.test.RedisCleanup
 import org.json4s.native.Serialization.write
-import org.scalatest.{BeforeAndAfterEach, FeatureSpec, Matchers}
+import org.scalatest.BeforeAndAfterEach
+import org.scalatest.featurespec.AnyFeatureSpec
+import org.scalatest.matchers.should.Matchers
 import redis.RedisClient
 
+import java.util.UUID
 import scala.concurrent.Await
 import scala.concurrent.duration._
 import scala.language.postfixOps
@@ -26,7 +27,7 @@ import scala.language.postfixOps
   * author: cvandrei
   * since: 2017-03-21
   */
-class OidcDirectiveSpec extends FeatureSpec with EmbeddedRedis
+class OidcDirectiveSpec extends AnyFeatureSpec with EmbeddedRedis
   with ScalatestRouteTest
   with Matchers
   with BeforeAndAfterEach
@@ -57,9 +58,9 @@ class OidcDirectiveSpec extends FeatureSpec with EmbeddedRedis
       }
     }
 
-  feature("oidcToken2UserContext") {
+  Feature("oidcToken2UserContext") {
 
-    scenario("with all headers but token does not exist") {
+    Scenario("with all headers but token does not exist") {
       withRedis(6379) { _ =>
         // prepare
         val authorizationHeader: HttpHeader = Authorization(OAuth2BearerToken("some-token"))
@@ -75,7 +76,7 @@ class OidcDirectiveSpec extends FeatureSpec with EmbeddedRedis
       }
     }
 
-    scenario("with Authorization header and token exists") {
+    Scenario("with Authorization header and token exists") {
       withRedis(6379) { _ =>
         // prepare
         val context = "some-context"
@@ -117,7 +118,7 @@ class OidcDirectiveSpec extends FeatureSpec with EmbeddedRedis
       }
     }
 
-    scenario("test case: without Authorization header") {
+    Scenario("test case: without Authorization header") {
 
       // test
       Get() ~> Route.seal(testRoute) ~> check {

--- a/src/test/scala/com/ubirch/util/oidc/directive/SignedUbirchTokenB64Spec.scala
+++ b/src/test/scala/com/ubirch/util/oidc/directive/SignedUbirchTokenB64Spec.scala
@@ -5,9 +5,11 @@ import com.typesafe.scalalogging.StrictLogging
 import com.ubirch.util.crypto.ecc.EccUtil
 import com.ubirch.util.redis.test.RedisCleanup
 import org.joda.time.{DateTime, DateTimeZone}
-import org.scalatest.{BeforeAndAfterEach, FeatureSpec, Matchers}
+import org.scalatest.BeforeAndAfterEach
+import org.scalatest.featurespec.AnyFeatureSpec
+import org.scalatest.matchers.should.Matchers
 
-class SignedUbirchTokenB64Spec extends FeatureSpec
+class SignedUbirchTokenB64Spec extends AnyFeatureSpec
   with ScalatestRouteTest
   with Matchers
   with BeforeAndAfterEach
@@ -15,7 +17,7 @@ class SignedUbirchTokenB64Spec extends FeatureSpec
   with StrictLogging {
 
   val eccUtil = new EccUtil
-  feature("basic test") {
+  Feature("basic test") {
 
     ignore("simple check token 0") {
       val (pubKeyB64, privKeyB64) = eccUtil.generateEccKeyPairEncoded
@@ -50,7 +52,7 @@ class SignedUbirchTokenB64Spec extends FeatureSpec
 
       tsInt shouldBe timestampLong
 
-      val tsDT = new DateTime(timestampLong * 1000l, DateTimeZone.UTC)
+      val tsDT = new DateTime(timestampLong * 1000L, DateTimeZone.UTC)
 
       new EccUtil().validateSignature(pubKeyB64, signatureB64, payload) shouldBe true
 

--- a/src/test/scala/com/ubirch/util/oidc/util/OidcUtilSpec.scala
+++ b/src/test/scala/com/ubirch/util/oidc/util/OidcUtilSpec.scala
@@ -1,42 +1,43 @@
 package com.ubirch.util.oidc.util
 
 import com.ubirch.util.crypto.hash.HashUtil
-import org.scalatest.{FeatureSpec, Matchers}
+import org.scalatest.featurespec.AnyFeatureSpec
+import org.scalatest.matchers.should.Matchers
 
 /**
   * author: cvandrei
   * since: 2017-02-10
   */
-class OidcUtilSpec extends FeatureSpec
+class OidcUtilSpec extends AnyFeatureSpec
   with Matchers {
 
-  feature("stateToHashedKey()") {
+  Feature("stateToHashedKey()") {
 
-    scenario("all strings empty") {
+    Scenario("all strings empty") {
       runStateTest("", "")
     }
 
-    scenario("provider string empty") {
+    Scenario("provider string empty") {
       runStateTest("", "123123")
     }
 
-    scenario("state string empty") {
+    Scenario("state string empty") {
       runStateTest("google", "")
     }
 
-    scenario("none of the strings empty") {
+    Scenario("none of the strings empty") {
       runStateTest("google", "123123")
     }
 
   }
 
-  feature("tokenToHashedKey()") {
+  Feature("tokenToHashedKey()") {
 
-    scenario("token string empty") {
+    Scenario("token string empty") {
       runTokenTest("")
     }
 
-    scenario("token not empty") {
+    Scenario("token not empty") {
       runTokenTest("12341234")
     }
 

--- a/src/test/scala/com/ubirch/util/oidc/util/UbirchTokenUtilSpec.scala
+++ b/src/test/scala/com/ubirch/util/oidc/util/UbirchTokenUtilSpec.scala
@@ -1,43 +1,44 @@
 package com.ubirch.util.oidc.util
 
-import com.ubirch.crypto.PrivKeyEDDSA
 import com.ubirch.util.crypto.ecc.EccUtil
 import com.ubirch.util.crypto.hash.HashUtil
-import org.scalatest.{FeatureSpec, Matchers}
+import org.scalatest.featurespec.AnyFeatureSpec
+import org.scalatest.matchers.should.Matchers
+
 
 /**
   * author: cvandrei
   * since: 2018-03-15
   */
-class UbirchTokenUtilSpec extends FeatureSpec with Matchers {
+class UbirchTokenUtilSpec extends AnyFeatureSpec with Matchers {
 
-  feature("providerId") {
+  Feature("providerId") {
 
-    scenario("ensure value did not change") {
+    Scenario("ensure value did not change") {
       UbirchTokenUtil.providerId shouldBe "ubirchToken"
     }
 
   }
 
-  feature("delim") {
+  Feature("delim") {
 
-    scenario("ensure value did not change") {
+    Scenario("ensure value did not change") {
       UbirchTokenUtil.delim shouldBe "::"
     }
 
   }
 
-  feature("defaultSignature") {
+  Feature("defaultSignature") {
 
-    scenario("ensure value did not change") {
+    Scenario("ensure value did not change") {
       UbirchTokenUtil.defaultSignature shouldBe "to-be-specified"
     }
 
   }
 
-  feature("toUbirchToken()") {
+  Feature("toUbirchToken()") {
 
-    scenario("without private key") {
+    Scenario("without private key") {
 
       // prepare
       val context = "ubirch-local"
@@ -56,7 +57,7 @@ class UbirchTokenUtilSpec extends FeatureSpec with Matchers {
 
     }
 
-    scenario("with private key") {
+    Scenario("with private key") {
 
       // prepare
       val context = "ubirch-local"
@@ -79,9 +80,9 @@ class UbirchTokenUtilSpec extends FeatureSpec with Matchers {
 
   }
 
-  feature("hashEmail()") {
+  Feature("hashEmail()") {
 
-    scenario("hash --> sha256HexString() is applied") {
+    Scenario("hash --> sha256HexString() is applied") {
 
       // prepare
       val email = "test@ubirch.com"


### PR DESCRIPTION
- scala to 2.13.6
- scala-test to 3.2.10
- scala-logging 3.9.4
- akka-http to 10.2.7
- akka-stream to 2.6.18
- json4s to 4.0.3
- joda-time to 2.10.13
- slf4j.api 1.7.32
- logback 1.2.10
- scalatest-embedded-redis 0.4.0